### PR TITLE
fix: duplicate user flags now errors out

### DIFF
--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -1,19 +1,16 @@
-name: Release
+name: Debug-Release
 
 on:
-  workflow_run:
-    workflows: ['Lint and Test']
-    types:
-      - completed
-    branches: 
-      - main
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: write
 
 jobs:
   set-version-tag:
-    if: ${{ github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/build-debug') }}
     runs-on: ubuntu-24.04
     outputs:
       semVer: ${{ steps.gitversion.outputs.semVer }}
@@ -56,21 +53,12 @@ jobs:
           echo "Revision: $GITHUB_SHA"
           go run cmd/main.go run pipeline build:binary --set Version=v${SEMVER} --set Revision=$GITHUB_SHA
 
-      # tag repo
-      - name: tag repo
-        run: | 
-          echo "REVISION  -> $GITHUB_SHA"
-          echo "VERSION -> $GITVERSION_SEMVER"
-          git tag -a "v${SEMVER}" -m "ci tag release" $GITHUB_SHA
-          git push origin "v${SEMVER}"
-
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.set-version-tag.outputs.semVer }}
           # TODO: add additional info to the release
-          generate_release_notes: true
+          generate_release_notes: false
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./bin/*
-          prerelease: false
-      
+          prerelease: true

--- a/cmd/eirctl/testdata/generate.yml
+++ b/cmd/eirctl/testdata/generate.yml
@@ -5,7 +5,7 @@ contexts:
   podman:
     container:
       name: alpine:latest
-    env: 
+    env:
       GLOBAL_VAR: this is it
     envfile:
       exclude:
@@ -14,7 +14,7 @@ contexts:
     container:
       name: ensonostackseuweirdfmu.azurecr.io/ensono/eir-asciidoctor:latest
       container_args:
-        - -p 1313:1313
+        - -v foo:foo
       shell: pwsh
       shell_args:
         - -Command
@@ -26,7 +26,7 @@ contexts:
 ci_meta:
   targetOpts:
     github:
-      "on": 
+      "on":
         push:
           branches:
             - gfooo
@@ -39,7 +39,7 @@ pipelines:
         GLOBAL_VAR: prodPipeline
   graph:pipeline1:
     - task: graph:task2
-      depends_on: 
+      depends_on:
         - graph:task1
     - task: graph:task3
       depends_on: [graph:task1]
@@ -83,13 +83,13 @@ tasks:
     context: podman
 
   graph:task3:
-    command: 
+    command:
       - echo "hello, task3 in env ${ENV_NAME}"
     env:
       FOO: bar
 
   graph:task4:
-    command: | 
+    command: |
       echo "hello, task4 in env ${ENV_NAME}"
     context: podman
     env:

--- a/eirctl.yaml
+++ b/eirctl.yaml
@@ -43,14 +43,14 @@ pipelines:
     - task: vuln:check
     # govet is run as part of golint
     # - task: govet
-  
+
   test:unit:
     - task: clean
     - task: test_prereqs
     - task: test
       # env:
       #   DOCKER_HOST: unix:///var/run/docker.sock
-      depends_on: 
+      depends_on:
         - clean
         - test_prereqs
 
@@ -70,16 +70,16 @@ pipelines:
         BinName: eirctl
 
 tasks:
-  clean: 
-    command: 
+  clean:
+    command:
       - echo "running clean"
-      - | 
+      - |
         rm -rf bin/*
         rm -rf dist/*
         rm -rf vendor/*
         rm -rf .coverage
-  test_prereqs: 
-    command: 
+  test_prereqs:
+    command:
       - echo "running test pre-requisites"
       - |
         mkdir -p .coverage
@@ -87,12 +87,12 @@ tasks:
         go install github.com/axw/gocov/gocov@v1.0.0 && \
         go install github.com/AlekSi/gocov-xml@v1.0.0
     allow_failure: true
-  
+
   vuln:check:
     context: go1x
-    description: | 
+    description: |
       Runs a vulnerability scan against the code base
-    command: 
+    command:
       - |
         go install golang.org/x/vuln/cmd/govulncheck@latest
         govulncheck ./...
@@ -100,14 +100,15 @@ tasks:
   test:
     command:
       - |
-        mkdir -p .coverage 
+        mkdir -p .coverage
         export GOFLAGS=-buildvcs=false
-        go test $(go list ./... | grep -v /local/) -v -coverpkg=./... -race -mod=readonly -shuffle=on -coverprofile=.coverage/out -count=1 | tee .coverage/test.out
+        go test $(go list ./... | grep -v /local/) -v -coverpkg=./... -race -mod=readonly -shuffle=on -coverprofile=.coverage/out -count=1 $GO_TEST_EXTRA_ARGS | tee .coverage/test.out
         cat .coverage/test.out | go-junit-report > .coverage/report-junit.xml
         gocov convert .coverage/out | gocov-xml > .coverage/report-cobertura.xml
     env:
       # TODO: bug when exclude is set up on the context it should allow task level overwrites
       GOFLAGS: -buildvcs=false
+      # GO_TEST_EXTRA_ARGS="-run "Test_ImagePull"
     allow_failure: true
 
   build:
@@ -143,20 +144,20 @@ tasks:
     variables:
       RepoOwner: Ensono
       BinName: eirctl
-  
+
   build:container:
-    description: Builds the docker image 
+    description: Builds the docker image
     command: docker build --build-arg Version={{.Version}} --build-arg Revision={{.Revision}} -t eirctl:{{.Version}} .
 
   golint:
-   # in CI it is run 
+    # in CI it is run
     context: golint
     description: Runs the linter and go vet and other default static checks
     allow_failure: false
     command:
       # echo "lint ran with exit code: $?"
-      # pwd && ls -lat 
-      - | 
+      # pwd && ls -lat
+      - |
         golangci-lint run
 
   goreleaser:
@@ -172,30 +173,30 @@ tasks:
 
   schema_gen_deps:
     description: |
-      Installing dependencies for the struct type generation 
+      Installing dependencies for the struct type generation
     command:
       - pnpm install -g quicktype
-  
+
   generate_own_schema:
-    description: | 
+    description: |
       Generates the schema for a eirctl itself.
-      
+
       Exits in CI if changes detected.
     command:
       - go run tools/schemagenerator/main.go
-      - | 
-        if [ ! -z "$(git status --porcelain --untracked-files=no)" ]; then 
+      - |
+        if [ ! -z "$(git status --porcelain --untracked-files=no)" ]; then
           if [ ! -z ${CI+x} ] ; then
             echo "In CI with an unclean tree - exiting"
             echo "Info: make sure you have generatedschema and committed"
             exit 1
           fi
         fi
-  
+
   generate_ci_structs_from_schema:
     description: |
       Type generation for target CI definitions used by the generate command
-           CI Definitions will be used by generate-def command.
+      CI Definitions will be used by generate-def command.
     command:
       - mkdir -p ./internal/z_generated/github
       - quicktype --lang go --src-lang schema --src ./internal/schema/sources/sources/github.json -o internal/z_generated/github/schema.go --field-tags yaml \

--- a/eirctl.yaml
+++ b/eirctl.yaml
@@ -101,9 +101,7 @@ tasks:
     command:
       - |
         mkdir -p .coverage
-        export GOFLAGS=-buildvcs=false
-        set -x
-        go test $(go list ./... | grep -v /local/) -v -coverpkg=./... -race -mod=readonly -shuffle=on -coverprofile=.coverage/out -count=1 -run=$GO_TEST_RUN_ARGS | tee .coverage/test.out
+        go test $(go list ./... | grep -v /local/) -v -coverpkg=./... -race -mod=readonly -shuffle=on -buildvcs=false -coverprofile=.coverage/out -count=1 -run=$GO_TEST_RUN_ARGS | tee .coverage/test.out
         cat .coverage/test.out | go-junit-report > .coverage/report-junit.xml
         gocov convert .coverage/out | gocov-xml > .coverage/report-cobertura.xml
     env:

--- a/eirctl.yaml
+++ b/eirctl.yaml
@@ -102,13 +102,14 @@ tasks:
       - |
         mkdir -p .coverage
         export GOFLAGS=-buildvcs=false
-        go test $(go list ./... | grep -v /local/) -v -coverpkg=./... -race -mod=readonly -shuffle=on -coverprofile=.coverage/out -count=1 $GO_TEST_EXTRA_ARGS | tee .coverage/test.out
+        set -x
+        go test $(go list ./... | grep -v /local/) -v -coverpkg=./... -race -mod=readonly -shuffle=on -coverprofile=.coverage/out -count=1 -run=$GO_TEST_RUN_ARGS | tee .coverage/test.out
         cat .coverage/test.out | go-junit-report > .coverage/report-junit.xml
         gocov convert .coverage/out | gocov-xml > .coverage/report-cobertura.xml
     env:
       # TODO: bug when exclude is set up on the context it should allow task level overwrites
       GOFLAGS: -buildvcs=false
-      # GO_TEST_EXTRA_ARGS="-run "Test_ImagePull"
+      # GO_TEST_RUN_ARGS: "Test_ImagePull"
     allow_failure: true
 
   build:

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -118,11 +118,7 @@ func contextExecutable(container *utils.Container) (*runner.ContainerContext, er
 		}
 
 		// CONTAINER ARGS these are best left to be tightly controlled
-		_, err = cc.ParseContainerArgs(checkForbiddenContainerArgs(container.ContainerArgs))
-
-		// TODO: Should this have a test, where, how? Seems like others in this
-		// file aren't covered currently...
-		if err != nil {
+		if _, err := cc.ParseContainerArgs(checkForbiddenContainerArgs(container.ContainerArgs)); err != nil {
 			return nil, err
 		}
 

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -171,7 +171,7 @@ func checkForbiddenContainerArgs(cargs []string) []string {
 				idx := slices.Index(cargs, s)
 				// when looking for pairs need to append both the flag and flag value
 				//
-				verbotenArgIdx = append(verbotenArgIdx, idx-1, idx)
+				verbotenArgIdx = append(verbotenArgIdx, idx)
 			}
 			return false
 		})

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -116,8 +116,16 @@ func contextExecutable(container *utils.Container) (*runner.ContainerContext, er
 			}
 			cc.WithVolumes(fmt.Sprintf("%s:/var/run/docker.sock", dockerHostPath))
 		}
+
 		// CONTAINER ARGS these are best left to be tightly controlled
-		cc.ParseContainerArgs(checkForbiddenContainerArgs(container.ContainerArgs))
+		_, err = cc.ParseContainerArgs(checkForbiddenContainerArgs(container.ContainerArgs))
+
+		// TODO: Should this have a test, where, how? Seems like others in this
+		// file aren't covered currently...
+		if err != nil {
+			return nil, err
+		}
+
 		if container.Entrypoint != nil {
 			cc.Entrypoint = container.Entrypoint
 		}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -358,6 +358,7 @@ func TestLoader_contexts_with_containerArgs(t *testing.T) {
 	}
 	for name, tt := range ttests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			dir, _ := os.MkdirTemp(os.TempDir(), "context*")
 			fname := filepath.Join(dir, "context.yaml")
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -70,7 +70,7 @@ tasks:
 			t.Errorf("failed to write bytes to response stream")
 		}
 	}))
-	loaderTYaml := fmt.Sprintf(`import: 
+	loaderTYaml := fmt.Sprintf(`import:
   - %s
   - %s
   - %s
@@ -221,7 +221,7 @@ func TestLoader_contexts(t *testing.T) {
     quote: "'"
     envfile:
       generate: true
-      exclude: 
+      exclude:
         - PATH
   powershell:
     container:
@@ -309,7 +309,7 @@ func TestLoader_contexts_with_containerArgs(t *testing.T) {
       shell_args:
         - -NonInteractive
         - -Command
-      container_args: ["--some","-f","-v /var/run/docker.sock:/var/run/docker.sock","-other","--safe"]
+      container_args: ["--user foo","-v /var/run/docker.sock:/var/run/docker.sock"]
     envfile:
       exclude:
         - SOURCEVERSIONMESSAGE
@@ -327,7 +327,7 @@ func TestLoader_contexts_with_containerArgs(t *testing.T) {
       shell_args:
         - -NonInteractive
         - -Command
-      container_args: ["--some","-f","-other","--safe"]
+      container_args: ["--user foo","-v /foo:/foo"]
       enable_dind: true
     envfile:
       exclude:
@@ -335,7 +335,7 @@ func TestLoader_contexts_with_containerArgs(t *testing.T) {
         - JAVA
         - GO
         - HOMEBREW`),
-			expectVolsCount: 2,
+			expectVolsCount: 3,
 		},
 		"includes ONLY forbidden args": {
 			contexts: []byte(`contexts:

--- a/runner/container_opts_unix.go
+++ b/runner/container_opts_unix.go
@@ -46,7 +46,11 @@ func platformContainerConfig(containerContext *ContainerContext, cEnv []string, 
 		User:       containerContext.User(),
 	}
 
-	hostConfig := &container.HostConfig{Mounts: []mount.Mount{}, Binds: []string{}}
+	hostConfig := &container.HostConfig{
+		Mounts:     []mount.Mount{},
+		Binds:      []string{},
+		UsernsMode: container.UsernsMode(containerContext.userns),
+	}
 	for _, volume := range containerContext.BindMounts() {
 		if containerContext.BindMount {
 			// use the new mounts

--- a/runner/container_opts_windows.go
+++ b/runner/container_opts_windows.go
@@ -39,7 +39,10 @@ func platformContainerConfig(containerContext *ContainerContext, cEnv []string, 
 		User:       containerContext.User(),
 	}
 
-	hostConfig := &container.HostConfig{Mounts: []mount.Mount{}}
+	hostConfig := &container.HostConfig{
+		Mounts:     []mount.Mount{},
+		UsernsMode: container.UsernsMode(containerContext.userns),
+	}
 	// only mount of type bind  can be used on windows
 	for _, volume := range containerContext.BindMounts() {
 		hostConfig.Mounts = append(hostConfig.Mounts, mount.Mount{

--- a/runner/context.go
+++ b/runner/context.go
@@ -96,6 +96,8 @@ func newContainerArgs(cargs []string) *containerArgs {
 	_ = flagSet.StringArrayP("volume", "v", []string{}, "")
 	flagSet.VarP(userVarFlag, "user", "u", "")
 	_ = flagSet.StringP("userns", "", "", "")
+	// TODO: refactor this to use first class properties
+	// on the container object in config/container_definition
 
 	return &containerArgs{cargs, flagSet}
 }

--- a/runner/context.go
+++ b/runner/context.go
@@ -68,7 +68,13 @@ func (c *ContainerContext) ParseContainerArgs(cargs []string) (*ContainerContext
 		return nil, err
 	}
 
-	c.parseVolumes(cargs)
+	cargs = c.parseVolumes(cargs)
+
+	_, err = c.parseRemaining(cargs)
+
+	if err != nil {
+		return nil, err
+	}
 
 	return c, nil
 }
@@ -121,6 +127,14 @@ func (c *ContainerContext) parseUserArgs(cargs []string) ([]string, error) {
 	}
 
 	return newCargs, nil
+}
+
+func (c *ContainerContext) parseRemaining(cargs []string) ([]string, error) {
+	if len(cargs) != 0 {
+		return nil, fmt.Errorf("unparsed arguments detected: %v", cargs)
+	}
+
+	return cargs, nil
 }
 
 // expandVolumeString accepts a string in the form of:

--- a/runner/context.go
+++ b/runner/context.go
@@ -65,16 +65,16 @@ type containerArgs struct {
 	flagSet *pflag.FlagSet
 }
 
-type userFlagString struct {
+type singleUseFlagString struct {
 	val   string
 	count int
 }
 
-func (s *userFlagString) String() string {
+func (s *singleUseFlagString) String() string {
 	return s.val
 }
 
-func (s *userFlagString) Set(v string) error {
+func (s *singleUseFlagString) Set(v string) error {
 	s.count++
 	if s.count > 1 {
 		return fmt.Errorf("error in container_args, user flag (-u/--user) already specified (%v). found: %s", s.val, v)
@@ -83,7 +83,7 @@ func (s *userFlagString) Set(v string) error {
 	return nil
 }
 
-func (s *userFlagString) Type() string {
+func (s *singleUseFlagString) Type() string {
 	return "string"
 }
 
@@ -91,7 +91,7 @@ func newContainerArgs(cargs []string) *containerArgs {
 	// Create a new FlagSet to parse this single flag
 	// let pflag do the work
 	// Add additional flags we want to handle here
-	userVarFlag := &userFlagString{}
+	userVarFlag := &singleUseFlagString{}
 	flagSet := pflag.NewFlagSet("containerArgsTempFlags", pflag.ContinueOnError)
 	_ = flagSet.StringArrayP("volume", "v", []string{}, "")
 	flagSet.VarP(userVarFlag, "user", "u", "")

--- a/runner/context_test.go
+++ b/runner/context_test.go
@@ -316,11 +316,6 @@ func Test_ContainerContext_UserArgs(t *testing.T) {
 			want:          "foo:bar",
 			expectErr:     false,
 		},
-		"empty": {
-			containerArgs: []string{"-v $HOME/bar:/in", " -bar foo:bar"},
-			want:          "",
-			expectErr:     false,
-		},
 		"-u bar and --user foo": {
 			containerArgs: []string{"-u bar", "-v /foo/bar:/in", "-v /foo/baz:/two", "--user foo"},
 			want:          "",
@@ -353,6 +348,55 @@ func Test_ContainerContext_UserArgs(t *testing.T) {
 				t.Errorf("not expecting an error: %s", err)
 				t.FailNow()
 			}
+
+			if err == nil {
+				if tt.expectErr {
+					t.Errorf("expecting an error for duplicate user flags, got: %s", got)
+					t.FailNow()
+				}
+
+				if got != tt.want {
+					t.Errorf("incorrect user mapping, got: %s, wanted: %s\n", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func Test_ContainerContext_UnsupportedArgs(t *testing.T) {
+	ttests := map[string]struct {
+		containerArgs []string
+		want          string
+		expectErr     bool
+	}{
+		"--foo": {
+			containerArgs: []string{"--foo"},
+			want:          "",
+			expectErr:     true,
+		},
+		"--bar": {
+			containerArgs: []string{"--bar"},
+			want:          "",
+			expectErr:     true,
+		},
+		"-u bar and --foo foo": {
+			containerArgs: []string{"-u bar", "--foo foo"},
+			want:          "",
+			expectErr:     true,
+		},
+	}
+	for name, tt := range ttests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cc := runner.NewContainerContext("image:latest")
+			_, err := cc.ParseContainerArgs(tt.containerArgs)
+
+			if err != nil && !tt.expectErr {
+				t.Errorf("not expecting an error: %s", err)
+				t.FailNow()
+			}
+
+			got := cc.User()
 
 			if err == nil {
 				if tt.expectErr {

--- a/runner/context_test.go
+++ b/runner/context_test.go
@@ -296,35 +296,73 @@ func Test_ContainerContext_Volumes(t *testing.T) {
 }
 
 func Test_ContainerContext_UserArgs(t *testing.T) {
-	t.Parallel()
 	ttests := map[string]struct {
 		containerArgs []string
 		want          string
+		expectErr     bool
 	}{
 		"--user foo": {
 			containerArgs: []string{"-v /foo/bar:/in", "-v /foo/baz:/two", "--user foo"},
 			want:          "foo",
+			expectErr:     false,
 		},
 		"-u foo": {
 			containerArgs: []string{"-v $PWD/bar:/in", "-v /foo/baz:/two", "-u foo"},
 			want:          "foo",
+			expectErr:     false,
 		},
 		" -u foo:bar": {
 			containerArgs: []string{"-v $HOME/bar:/in", " -u foo:bar"},
 			want:          "foo:bar",
+			expectErr:     false,
 		},
-		" empty ": {
+		"empty": {
 			containerArgs: []string{"-v $HOME/bar:/in", " -bar foo:bar"},
 			want:          "",
+			expectErr:     false,
+		},
+		"-u bar and --user foo": {
+			containerArgs: []string{"-u bar", "-v /foo/bar:/in", "-v /foo/baz:/two", "--user foo"},
+			want:          "",
+			expectErr:     true,
+		},
+		"-u bar and -u foo": {
+			containerArgs: []string{"-u bar", "-v /foo/bar:/in", "-u foo", "-v /foo/baz:/two"},
+			want:          "",
+			expectErr:     true,
+		},
+		"-u foo and -u foo": {
+			containerArgs: []string{"-u foo", "-v /foo/bar:/in", "-u foo", "-v /foo/baz:/two"},
+			want:          "",
+			expectErr:     true,
+		},
+		"--user bar and --user foo": {
+			containerArgs: []string{"--user bar", "-v /foo/bar:/in", "--user foo", "-v /foo/baz:/two"},
+			want:          "",
+			expectErr:     true,
 		},
 	}
 	for name, tt := range ttests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			cc := runner.NewContainerContext("image:latest")
-			cc.ParseContainerArgs(tt.containerArgs)
+			_, err := cc.ParseContainerArgs(tt.containerArgs)
 			got := cc.User()
-			if got != tt.want {
-				t.Errorf("incorect volume mappging, got: %s, wanted: %s\n", got, tt.want)
+
+			if err != nil && !tt.expectErr {
+				t.Errorf("not expecting an error: %s", err)
+				t.FailNow()
+			}
+
+			if err == nil {
+				if tt.expectErr {
+					t.Errorf("expecting an error for duplicate user flags, got: %s", got)
+					t.FailNow()
+				}
+
+				if got != tt.want {
+					t.Errorf("incorrect user mapping, got: %s, wanted: %s\n", got, tt.want)
+				}
 			}
 		})
 	}

--- a/runner/context_test.go
+++ b/runner/context_test.go
@@ -302,12 +302,12 @@ func Test_ContainerContext_UserArgs(t *testing.T) {
 		expectErr     bool
 	}{
 		"--user foo": {
-			containerArgs: []string{"-v /foo/bar:/in", "-v /foo/baz:/two", "--user foo"},
+			containerArgs: []string{"-v /foo/bar:/in", "-v /foo/baz:/two", "--user foo", "--userns private"},
 			want:          "foo",
 			expectErr:     false,
 		},
 		"-u foo": {
-			containerArgs: []string{"-v $PWD/bar:/in", "-v /foo/baz:/two", "-u foo"},
+			containerArgs: []string{"-v $PWD/bar:/in", "--volume /foo/baz:/two", "-u foo"},
 			want:          "foo",
 			expectErr:     false,
 		},
@@ -321,8 +321,8 @@ func Test_ContainerContext_UserArgs(t *testing.T) {
 			want:          "",
 			expectErr:     true,
 		},
-		"-u bar and -u foo": {
-			containerArgs: []string{"-u bar", "-v /foo/bar:/in", "-u foo", "-v /foo/baz:/two"},
+		"-u bar and --user=foo": {
+			containerArgs: []string{"-u bar", "-v /foo/bar:/in", "--user=foo", "-v /foo/baz:/two"},
 			want:          "",
 			expectErr:     true,
 		},

--- a/runner/executor_container.go
+++ b/runner/executor_container.go
@@ -155,7 +155,7 @@ func (e *ContainerExecutor) createContainer(ctx context.Context, containerConfig
 	resp, err := e.cc.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			if err := e.PullImage(ctx, containerConfig, job.Stdout); err != nil {
+			if err := e.PullImage(ctx, containerConfig); err != nil {
 				return container.CreateResponse{}, err
 			}
 			// Image pulled now create container
@@ -314,7 +314,7 @@ func (e *ContainerExecutor) resizeShellTTY(ctx context.Context, fd int, containe
 
 // Container pull images - all contexts that have a container property
 // TODO: Why is dstOutput never used?
-func (e *ContainerExecutor) PullImage(ctx context.Context, containerConf *container.Config, dstOutput io.Writer) error {
+func (e *ContainerExecutor) PullImage(ctx context.Context, containerConf *container.Config) error {
 	logrus.Debugf("pulling image: %s", containerConf.Image)
 	pullOpts, err := platformPullOptions(ctx, containerConf)
 	if err != nil {

--- a/runner/executor_container.go
+++ b/runner/executor_container.go
@@ -313,6 +313,7 @@ func (e *ContainerExecutor) resizeShellTTY(ctx context.Context, fd int, containe
 }
 
 // Container pull images - all contexts that have a container property
+// TODO: Why is dstOutput never used?
 func (e *ContainerExecutor) PullImage(ctx context.Context, containerConf *container.Config, dstOutput io.Writer) error {
 	logrus.Debugf("pulling image: %s", containerConf.Image)
 	pullOpts, err := platformPullOptions(ctx, containerConf)

--- a/runner/executor_container.go
+++ b/runner/executor_container.go
@@ -313,7 +313,6 @@ func (e *ContainerExecutor) resizeShellTTY(ctx context.Context, fd int, containe
 }
 
 // Container pull images - all contexts that have a container property
-// TODO: Why is dstOutput never used?
 func (e *ContainerExecutor) PullImage(ctx context.Context, containerConf *container.Config) error {
 	logrus.Debugf("pulling image: %s", containerConf.Image)
 	pullOpts, err := platformPullOptions(ctx, containerConf)

--- a/runner/executor_container_test.go
+++ b/runner/executor_container_test.go
@@ -555,6 +555,7 @@ for i in $(seq 1 10); do echo "hello, iteration $i"; done`,
 	})
 
 	t.Run("correctly mounts host dir", func(t *testing.T) {
+		// t.Skip("move to integration tests...")
 		cc := runner.NewContainerContext("alpine:3.21.3")
 		cc.ShellArgs = []string{"sh", "-c"}
 		cc.BindMount = true

--- a/runner/executor_container_test.go
+++ b/runner/executor_container_test.go
@@ -112,10 +112,7 @@ func Test_ImagePull(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		containerConfig := container.Config{}
-		containerConfig.Image = cc.Image
-
-		if err := nce.PullImage(context.TODO(), &containerConfig, io.Discard); err != nil {
+		if err := nce.PullImage(context.TODO(), &container.Config{Image: cc.Image}); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/runner/executor_container_test.go
+++ b/runner/executor_container_test.go
@@ -112,7 +112,10 @@ func Test_ImagePull(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := nce.PullImage(context.TODO(), &container.Config{}, io.Discard); err != nil {
+		containerConfig := container.Config{}
+		containerConfig.Image = cc.Image
+
+		if err := nce.PullImage(context.TODO(), &containerConfig, io.Discard); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
 * Supplying duplicate user flags now errors out
 * Test didn't pass locally (corrected to pass Image in)
 * Container args passed to successive parsers now only parse flags not consumed by the previous one in the chain. This opens up future enhancements, such as adding `--userns` support as the successive --user flag wouldn't receive and incorrectly parse it as `--user` and `ns=host`
 * Error out on unparsed container arguments