### PR TITLE
Documentation Tidy Up

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -657,7 +657,7 @@ notice like this when it starts in an interactive mode:
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
-The hypothetical commands `show w' and `show c' should show the appropriate
+The hypothetical commands `show w' and`show c' should show the appropriate
 parts of the General Public License.  Of course, your program's commands
 might be different; for a GUI interface, you would use an "about box".
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The CLI offers a range of commands, most of them needs a valid config file.
 - `list`: Lists contexts, pipelines, tasks and watchers.
 - `run`: Runs a pipeline or a task, see `eirctl run -h` for more options.
 - `shell`: Shell into the supplied container-context, works only with the native container context. (Beta Feature)
-- `show` Shows task's details.
+- `show`: Shows task's details.
 - `validate` Validates config file.
 - `watch`: Watches changes in directories to perform certain tasks (see [watchers](docs/watchers.md)).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The CLI offers a range of commands, most of them needs a valid config file.
 - `run`: Runs a pipeline or a task, see `eirctl run -h` for more options.
 - `shell`: Shell into the supplied container-context, works only with the native container context. (Beta Feature)
 - `show`: Shows task's details.
-- `validate` Validates config file.
+- `validate`: Validates config file.
 - `watch`: Watches changes in directories to perform certain tasks (see [watchers](docs/watchers.md)).
 
 ## Tasks

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Additional concepts:
 The CLI offers a range of commands, each of them needs a valid config file.
 
 > [!NOTE]
-> eirctl <pipeline|task> will behave as `eirctl run pipeline|task`
+> `eirctl <pipeline|task>` will behave as `eirctl run pipeline|task`
 
 - `completion`: Generate the autocompletion script for the specified shell (`bash`, `fish`, `powershell` or `zsh`).
 - `generate`: Generates a CI definition in a target implementation from a `eirctl` pipeline definition.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Ensono_eirctl&metric=coverage&token=e86946cc9dca27f76752e1e7ba256b38a4aa9196)](https://sonarcloud.io/summary/new_code?id=Ensono_eirctl)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Ensono_eirctl&metric=alert_status&token=e86946cc9dca27f76752e1e7ba256b38a4aa9196)](https://sonarcloud.io/summary/new_code?id=Ensono_eirctl)
 
-`eirctl` is a build tool alternative to GNU Make, like it's inspiration [taskctl](https://github.com/taskctl/taskctl), taskfile and others it is cross-platform and cross-architecture, so it works on Windows, Linux and MacOS on either `amd64` or `arm64`, as the Go source code is provided it can be compiled for any architecture supported by the language and the project dependencies.
+`eirctl` is a build tool alternative to GNU Make, like its inspiration [taskctl](https://github.com/taskctl/taskctl), taskfile and others it is cross-platform and cross-architecture, so it works on Windows, Linux and MacOS on either `amd64` or `arm64`, as the Go source code is provided it can be compiled for any architecture supported by the language and the project dependencies.
 
 > [!NOTE]
 > As with most things Windows, this comes with a few caveats:

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Ensono_eirctl&metric=coverage&token=e86946cc9dca27f76752e1e7ba256b38a4aa9196)](https://sonarcloud.io/summary/new_code?id=Ensono_eirctl)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Ensono_eirctl&metric=alert_status&token=e86946cc9dca27f76752e1e7ba256b38a4aa9196)](https://sonarcloud.io/summary/new_code?id=Ensono_eirctl)
 
-EirCtl is a build tool alternative to GNU Make, as with some of the others like it's inspiration [taskctl](https://github.com/taskctl/taskctl) and taskfile and others it is cross platform so works on windows.
+`eirctl` is a build tool alternative to GNU Make, like it's inspiration [taskctl](https://github.com/taskctl/taskctl), taskfile and others it is cross-platform and cross-architecture, so it works on Windows, Linux and MacOS on either `amd64` or `arm64`, as the Go source code is provided it can be compiled for any architecture supported by the language and the project dependencies.
 
 > [!NOTE]
-> As with most things windows, this comes with a few caveats
+> As with most things Windows, this comes with a few caveats:
+>
+> - use of a modern shell (i.e. Powershell 5+)
+> - use of a terminal emulator supporting modern constructs (i.e. Windows Terminal)
+> - ensure that the correct line endings are in use, use git's `autocrlf` if necessary
 
 Whilst it is built within the Ensono ecosystem and is used within the Ensono Independent Runner and Ensono Stacks, **it can and is used in isolation**.
 
@@ -27,19 +31,19 @@ The configuration is driven through YAML which has its [schema](https://raw.gith
 
 Key concepts, see below for more details.
 
-- [task](#tasks) => defines a series of commands and their possible variations which compile down to a job
+- [task](#tasks) → defines a series of commands and their possible variations which compile down to a job
 - [contexts](#contexts)
 - [pipelines](#pipelines)
 - [imports](./docs/import.md)
 
 Additional concepts:
 
-- execution graphs can be seen [here in more detail.](./docs/graph-implementation.md)
+- [execution graphs](./docs/graph-implementation.md)
 - [native container support](#docker-context)
 
 ### CLI
 
-The CLI offers a range of commands, each of them needs a valid config file.
+The CLI offers a range of commands, most of them needs a valid config file.
 
 > [!NOTE]
 > `eirctl <pipeline|task>` will behave as `eirctl run pipeline|task`
@@ -59,7 +63,7 @@ The CLI offers a range of commands, each of them needs a valid config file.
 
 ### Tasks variables
 
-Each task, stage and context has variables to be used to render task's fields  - `command`, `dir`.
+Each task, stage and context has variables to be used to render task's fields - `command`, `dir`.
 Along with globally predefined, variables can be set in a task's definition.
 You can use those variables according to `text/template` [documentation](https://pkg.go.dev/text/template).
 
@@ -109,7 +113,7 @@ The computational check happens at runtime and not compile time - currently - th
 This comes with potential delay of catching of issues, the current implementation will collect all errors before returning to avoid back and forth.
 
 > [!IMPORTANT]
-> Potentially some aspects of this could be moved to the validate subcomand.
+> Potentially some aspects of this could be moved to the validate subcommand.
 
 ```yaml
 task:requiredVar:
@@ -123,7 +127,7 @@ task:requiredVar:
 `REQUIRED_ENV=isSet eirctl run task task:requiredVar --set SetMe=thats-right`
 
 > [!TIP]
-> When running this task in an eirctl pipeline, `REQUIRED_ENV` can be set in a previous task, in global env, in an envfile, via a direct assignment the parent pipline(s).
+> When running this task in an eirctl pipeline, `REQUIRED_ENV` can be set in a previous task, in global env, in an envfile, via a direct assignment the parent pipeline(s).
 
 ### Storing task's output
 
@@ -328,7 +332,7 @@ tasks:
 
 Whilst they are all valid to achieve a similar outcome, each depends on the use case.
 
-_some downsides of the `old:container` context_
+### some downsides of the `old:container` context
 
 - The lack of changing env injection with the `old:container` context, it does not support variations properly on the task as it pre-creates a set of environment variables.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The configuration is driven through YAML which has its [schema](https://raw.gith
 
 Key concepts, see below for more details.
 
-- [task](#tasks) => defines a series of commands and their possible variations which compile down to a [job](#job)
+- [task](#tasks) => defines a series of commands and their possible variations which compile down to a job
 - [contexts](#contexts)
 - [pipelines](#pipelines)
 - [imports](./docs/import.md)
@@ -41,49 +41,19 @@ Additional concepts:
 
 The CLI offers a range of commands, each of them needs a valid config file.
 
-- `completion`
-  
-  Generate the autocompletion script for the specified shell
-- `generate`
-  
-  Generates a CI definition in a target implementation from a Eirctl pipeline definition.
-
-- `graph`
-  
-  Visualizes pipeline execution graph
-- `help`
-  
-  Help about any command
-- `init`
-  
-  Initializes the directory with a- sample config file
-
-- `list`
-  
-  Lists contexts, pipelines, tasks- and watchers
-
-- `run`
-
-  Runs a pipeline or a task, see `eirctl run -h` for more options.
-  
-> [!INFO]
+> [!INFORMATION]
 > eirctl <pipeline|task> will behave as `eirctl run pipeline|task`
 
-- `shell [beta]`
-  
-  Shell into the supplied container-context, works only with the native container context
-
-- `show`
-  
-  Shows task's details
-
-- `validate`
-  
-  Validates config file
-
-- `watch`
-  
-  Watches changes in directories to perform certain tasks [WATCHERS...]
+- `completion`: Generate the autocompletion script for the specified shell (`bash`, `fish`, `powershell` or `zsh`).
+- `generate`: Generates a CI definition in a target implementation from a `eirctl` pipeline definition.
+- `graph`: Visualizes pipeline execution graph.
+- `init`: Initializes the directory with a sample config file.
+- `list`: Lists contexts, pipelines, tasks and watchers.
+- `run`: Runs a pipeline or a task, see `eirctl run -h` for more options.
+- `shell`: Shell into the supplied container-context, works only with the native container context. (Beta Feature)
+- `show` Shows task's details.
+- `validate` Validates config file.
+- `watch` Watches changes in directories to perform certain tasks (see [watchers](docs/watchers.md)).
 
 ## Tasks
 
@@ -91,7 +61,7 @@ The CLI offers a range of commands, each of them needs a valid config file.
 
 Each task, stage and context has variables to be used to render task's fields  - `command`, `dir`.
 Along with globally predefined, variables can be set in a task's definition.
-You can use those variables according to `text/template` [documentation](https://golang.org/pkg/text/template/).
+You can use those variables according to `text/template` [documentation](https://pkg.go.dev/text/template).
 
 Predefined variables are:
 
@@ -142,12 +112,12 @@ This comes with potential delay of catching of issues, the current implementatio
 > Potentially some aspects of this could be moved to the validate subcomand.
 
 ```yaml
-  task:requiredVar:
-    command: echo "var has been set {{ .SetMe }} and required env ${REQUIRED_ENV}"
-    required:
-      env: [REQUIRED_ENV]
-      vars:
-        - SetMe
+task:requiredVar:
+  command: echo "var has been set {{ .SetMe }} and required env ${REQUIRED_ENV}"
+  required:
+    env: [REQUIRED_ENV]
+    vars:
+      - SetMe
 ```
 
 `REQUIRED_ENV=isSet eirctl run task task:requiredVar --set SetMe=thats-right`
@@ -244,7 +214,7 @@ Stage definition takes following parameters:
 - `condition` - condition to check before running stage
 - `variables` - stage's variables
 
-## output formats
+## Output formats
 
 eirctl has several output formats:
 
@@ -259,7 +229,7 @@ Contexts allow you to set up execution environment, variables, binary which will
 The context has the lowest precedence in environment variable setting - i.e. it will be overwritten by pipeline → task level variables - [more info here](./docs/graph-implementation.md#environment-variables).
 
 > [!NOTE]
-> _evnfile_ property on the context allows for further customization of the injected environment.
+> _envfile_ property on the context allows for further customization of the injected environment.
 > It can merge env from a file or mutate/include/exclude existing environment - see the [schema](./schemas/schema_v1.json) for more details
 
 _Tasks running without a context_ will be run in a [cross platform shell](https://github.com/mvdan/sh). You can follow any issues on the project site with GNU tool conversion of host->mvdan emulator shell mapping.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The CLI offers a range of commands, most of them needs a valid config file.
 - `shell`: Shell into the supplied container-context, works only with the native container context. (Beta Feature)
 - `show` Shows task's details.
 - `validate` Validates config file.
-- `watch` Watches changes in directories to perform certain tasks (see [watchers](docs/watchers.md)).
+- `watch`: Watches changes in directories to perform certain tasks (see [watchers](docs/watchers.md)).
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Additional concepts:
 
 The CLI offers a range of commands, each of them needs a valid config file.
 
-> [!INFORMATION]
+> [!NOTE]
 > eirctl <pipeline|task> will behave as `eirctl run pipeline|task`
 
 - `completion`: Generate the autocompletion script for the specified shell (`bash`, `fish`, `powershell` or `zsh`).

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Thank you!
 
 ## License
 
-This project is licensed under the GNU GPLv3 - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the GNU GPLv3 - see the [LICENSE](LICENSE) file for details
 
 ## Acknowledgments
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,17 +1,19 @@
 # Artifacts
 
+> [!NOTE]
 > Removed the scrape of stdout as a default Output storage after every task
 
-Any task can assign outputs in a form of files or a special dotenv format output which is then added to the tascktl runner and available to all the subsequent tasks.
+Any task can assign outputs in a form of files or a special dotenv format output which is then added to the taskctl runner and available to all the subsequent tasks.
 
 ## Dotenv
 
-The artifacts are only usefil inside pipelines, ensuring you provide a depends on will make sure the variables are ready.
+The artifacts are only useful inside pipelines, ensuring you provide a depends on will make sure the variables are ready.
 
 The outputs are available across contexts.
 
 Example below uses the default context to generate some stored artifact and then it is used in a container context.
 
+> [!TIP]
 > after commands are not stored as artifacts
 
 ```yaml
@@ -60,9 +62,10 @@ tasks:
 
 ## Env [Experimental]
 
-When writing a command and a bash style setting of a variable or export is placed in the command along with a artifacts capture specified as `env` the downstream tasks in a pipeline are able to pick them up as environmnent variables
+When writing a command and a bash style setting of a variable or export is placed in the command along with a artifacts capture specified as `env` the downstream tasks in a pipeline are able to pick them up as environment variables
 
-> Experimental - take care when using in production. currently there is no prefixing of variables across tasks in pipelines so the runner environment will just be overwritten with newly set variables
+> [!IMPORTANT]
+> **Experimental** - take care when using in production. currently there is no prefixing of variables across tasks in pipelines so the runner environment will just be overwritten with newly set variables
 
 Using the prefix of `EIRCTL_TASK_OUTPUT_`
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -92,4 +92,5 @@ pipelines:
       depends_on: run:container:nouveau
 ```
 
+> [!NOTE]
 > Current limitation is that it has to be set directly in the task command and _NOT_ in a script called from command

--- a/docs/ci-generator.md
+++ b/docs/ci-generator.md
@@ -20,11 +20,9 @@ flowchart TD
     E --> X(Finish pipeline x)
 ```
 
-The example above shows `pipeline x` - starting by executing tasks a,b,c in parallel. `task d` waiting for `task c` to finish. 
+The example above shows `pipeline x` - starting by executing tasks a,b,c in parallel. `task d` waiting for `task c` to finish.
 
 `task e` waits for `task a`, `task b` and `task d` to complete before running.
-
-
 
 ## Implementation
 
@@ -45,8 +43,8 @@ The list of supported generators will grow as more are added. To add an addition
 
 Currently implemented:
 
-    - Github
-    - ...
+- Github
+- ...
 
 ## Sample outputs
 

--- a/docs/graph-implementation.md
+++ b/docs/graph-implementation.md
@@ -57,7 +57,7 @@ The general flow of inheritance is from the more general to the more specific, i
 > [!NOTE]
 > Presence of a file named `eirctl.env` (has to follow the nix style env file syntax `KEY=value`) will automatically make this part of the context environment variable. Will follow the same precedence as above.
 > [!TIP]
-envfile can specify a path to a custom .env file - which now supports in file references to variables, _it does not_ support a more advanced envsubst style of defaults and empty checkers.
+> envfile can specify a path to a custom .env file - which now supports in file references to variables, _it does not_ support a more advanced envsubst style of defaults and empty checkers.
 
 As the file is scanned line by line any referenced vars need to be specified after their declaration. See below for an example.
 

--- a/docs/graph-implementation.md
+++ b/docs/graph-implementation.md
@@ -1,13 +1,14 @@
 # Graph Internals
 
 The internal processes generate, essentially, an n-ary tree.
-The tree may have nodes which themselves are other trees. 
+The tree may have nodes which themselves are other trees.
 
+> [!IMPORTANT]
 > There are never any edges between nodes in a child tree to the parent tree, i.e. only single level stages (nodes) can `depends_on` on each other.
 
 The generated graphs will have the following legend, it can also be embedded in the generated digraph by specifying the `--legend` flag.
 
-![](./svg/legend.svg)
+![Legend](./svg/legend.svg)
 
 Blue arrows are the first level stages in the pipeline, these can be direct tasks or other pipelines.
 
@@ -29,17 +30,21 @@ To illustrate the point we can see the differences below across the same "pipeli
 
 The generated tree can be viewed in both the normalized form using the graph command.
 
-`taskctl graph gha:infra:sample -c ./cmd/eirctl/testdata/gha.sample.yml | dot -Tsvg -o normalized.svg`
+```console
+taskctl graph gha:infra:sample -c ./cmd/eirctl/testdata/gha.sample.yml | dot -Tsvg -o normalized.svg
+```
 
-![](./svg/normalized.svg)
+![Normalized form of the graph output](./svg/normalized.svg)
 
 ### Denormalized
 
 When running the run command with the `--graph-only` it would generate the denormalized tree graph.
 
-`taskctl run gha:infra:sample -c ./cmd/eirctl/testdata/gha.sample.yml --graph-only | dot -Tsvg -o docs/svg/denormalized.svg`
+```console
+taskctl run gha:infra:sample -c ./cmd/eirctl/testdata/gha.sample.yml --graph-only | dot -Tsvg -o docs/svg/denormalized.svg
+```
 
-![](./svg/denormalized.svg)
+![Denormalized form of the graph](./svg/denormalized.svg)
 
 ## Environment Variables
 
@@ -49,9 +54,10 @@ With denormalization performed for each `run` command we can perform a hierarchi
 
 The general flow of inheritance is from the more general to the more specific, i.e. `Context < Pipeline < Task`.
 
-> NB: presence of a file named `eirctl.env` (has to follow the nix style env file syntax `KEY=value`) will automatically make this part of the context environment variable. Will follow the same precedence as above.
-
-> envfile can specify a path to a custom .env file - which now supports in file references to variables, _it does not_ support a more advanced envsubst style of defaults and empty checkers. 
+> [!NOTE]
+> Presence of a file named `eirctl.env` (has to follow the nix style env file syntax `KEY=value`) will automatically make this part of the context environment variable. Will follow the same precedence as above.
+> [!TIP]
+envfile can specify a path to a custom .env file - which now supports in file references to variables, _it does not_ support a more advanced envsubst style of defaults and empty checkers.
 
 As the file is scanned line by line any referenced vars need to be specified after their declaration. See below for an example.
 
@@ -63,7 +69,7 @@ BAZ=${FOO}
 
 That means that anything set in the context level will always be injected into the pipeline and task, unless the same key is set in the pipeline in which case it will be overwritten.
 
-Anything set in a task will overwrite previouusly set env keys.
+Anything set in a task will overwrite previously set env keys.
 
 ### Precedence
 
@@ -116,17 +122,16 @@ pipelines:
 The path to `task:four` can be achieved in the following ways:
 
 - `tester->action:one->do-this->task:four`
-    - `action:one` is a pipeline that has a child `do-this` which is another pipeline, an alias to the `wrapped` pipeline which has the `task:four` in it.
-    - `task:four` will have these values:
-        - `FOO: task-set-val-always-wins`
-        - `SOME: set-level-1`
-        - `OTHER: this-do`
-    - `SOME` would be overwritten inside the `acion:one` `do-this` pipeline.
+  - `action:one` is a pipeline that has a child `do-this` which is another pipeline, an alias to the `wrapped` pipeline which has the `task:four` in it.
+  - `task:four` will have these values:
+    - `FOO: task-set-val-always-wins`
+    - `SOME: set-level-1`
+    - `OTHER: this-do`
+  - `SOME` would be overwritten inside the `acion:one` `do-this` pipeline.
 
 - `tester->action:two->do-that->task:four`
-    - `action:two` is a pipeline that has a child `do-that` which is another pipeline, an alias to the `wrapped` pipeline which has the `task:four` in it.
-    - `task:four` will have these values:
-        - `FOO: task-set-val-always-wins`
-        - `SOME: that`
-    - `SOME` would be inherited the `tester` referenced `action:two` pipeline.
-
+  - `action:two` is a pipeline that has a child `do-that` which is another pipeline, an alias to the `wrapped` pipeline which has the `task:four` in it.
+  - `task:four` will have these values:
+    - `FOO: task-set-val-always-wins`
+    - `SOME: that`
+  - `SOME` would be inherited the `tester` referenced `action:two` pipeline.

--- a/docs/import.md
+++ b/docs/import.md
@@ -16,12 +16,14 @@ import:
 
 When importing over HTTPS make sure the link returns the contents directly - e.g. on Github use a `raw.githubusercontent.com` snippet.
 
-> ideally it should be a .yaml extension
+> [!NOTE]
+> Ideally it should be a .yaml extension
 
 ## GIT
 
 When importing over Git - ideally you should use SSH with any private repositories and can use git over https with public ones if the provider does not support raw content urls like GH.
 
+> [!IMPORTANT]
 > Pattern must follow this regex `^git::(ssh|https?|file)://(.+?)//([^?]+)(?:\?ref=([^&]+))?$`
 
 Below protocols supported with Git
@@ -30,6 +32,7 @@ Below protocols supported with Git
 - HTTPS
 - FILE
 
+> [!TIP]
 > Optional ref can be set to either point to a branch/tag/commit_sha
 
 ## FILESYSTEM

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ curl -L https://github.com/Ensono/eirctl/releases/latest/download/eirctl-linux-a
 curl -L https://github.com/Ensono/eirctl/releases/latest/download/eirctl-darwin-arm64 -o eirctl
 ```
 
-For Linux and Mac users these files can be installed system wide by placing them in `/usr/local/bin` this should be in the pat for any normal user:
+For Linux and Mac users these files can be installed system wide by placing them in `/usr/local/bin` this should be in the path for any normal user:
 
 ```bash
 chmod +x eirctl
@@ -36,6 +36,9 @@ It is also possible to install on a per-user basis by copying to `~/.local/bin`:
 chmod +x eirctl
 mv eirctl $HOME/.local/bin
 ```
+
+> [!CAUTION]
+> Some distributions don't automatically add `$HOME/.local/bin` to the `$PATH`, ensure that it exists and has restrictive permissions, i.e. `750` and restart your shell as this path is only added to the `$PATH` if it exists when your `.profile` is executed.
 
 #### Windows Binary
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,53 +6,81 @@ You can install a prebuilt binary for your system from Github, see below the det
 
 ### Install
 
-Major platform binaries [here](https://github.com/Ensono/eirctl/releases)
+`eirctl` is compiled for all major platforms (Windows, Mac, Linux) and architectures (`amd64`, `arm64`) and downloadable from [GitHub Releases](https://github.com/Ensono/eirctl/releases).
 
-*nix binary
+#### Linux  binary
+
+> [!TIP]
+> Windows Subsystem for Linux users can use the linux instructions from within a WSL terminal.
 
 ```bash
 curl -L https://github.com/Ensono/eirctl/releases/latest/download/eirctl-linux-amd64 -o eirctl
 ```
 
-MacOS binary
+#### MacOS binary
 
 ```bash
 curl -L https://github.com/Ensono/eirctl/releases/latest/download/eirctl-darwin-arm64 -o eirctl
 ```
+
+For Linux and Mac users these files can be installed system wide by placing them in `/usr/local/bin` this should be in the pat for any normal user:
 
 ```bash
 chmod +x eirctl
 sudo mv eirctl /usr/local/bin
 ```
 
-Windows binaries for your platform can be downloaded manually, or via pwsh (`iwr` or similar) then moved to a `$env:PATH` on your computer.
-
-> Ideally on a path under your user, create one specifically for portable binaries e.g. `C:\Users\<yourname>\bin` or use an existing one from `$env:PATH`.
+It is also possible to install on a per-user basis by copying to `~/.local/bin`:
 
 ```sh
-https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-386.exe
-https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-amd64.exe
-https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-arm64.exe
+chmod +x eirctl
+mv eirctl $HOME/.local/bin
 ```
 
-Verify installation
+#### Windows Binary
+
+Windows binaries for your platform can be downloaded manually, or via pwsh (`iwr` or similar) then moved to a `$env:PATH` on your computer.
+
+> [!IMPORTANT]
+> Ideally use a path under your user's home directory, create one specifically for portable binaries e.g. `C:\Users\$USERNAME\bin` or use an existing one from `$env:PATH`.
+
+```pwsh
+$binDir = "${env:HOMEDRIVE}${env:HOMEPATH}\bin";
+New-Item -Path $binDir -ItemType Directory -ErrorAction SilentlyContinue;
+Invoke-WebRequest -Uri https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-amd64.exe -OutFile "${binDir}\eirctl.exe";
+$env:PATH="${env:PATH};${binDir}"
+```
+
+```sh
+https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-amd64.exe
+https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-arm64.exe
+https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-386.exe
+```
+
+### Verify installation
 
 ```bash
 eirctl --version
 ```
 
-Download specific version:
-
-_ARM_:
-
-```bash
-curl -L https://github.com/Ensono/eirctl/releases/download/0.7.2/eirctl-darwin-arm64 -o eirctl
+```output
+eirctl version v0.7.5-332295a31e95686cc9b20376d23a38cc98b45a00
 ```
 
-_AMD_:
+### Different Architectures
+
+Ensure that you download the correct version for the target architecture: amd64 (i.e. Intel / AMD) or ARM (i.e. Mac M1), if needed adjust the command as follows:
+
+#### ARM (i.e. Mac M\[1-4\])
 
 ```bash
-curl -L https://github.com/Ensono/eirctl/releases/download/0.7.2/eirctl-darwin-amd64 -o eirctl
+curl -L https://github.com/Ensono/eirctl/releases/latest/download/eirctl-darwin-arm64 -o eirctl
+```
+
+#### AMD (i.e. Intel Mac)
+
+```bash
+curl -L https://github.com/Ensono/eirctl/releases/latest/download/eirctl-darwin-amd64 -o eirctl
 ```
 
 ### Usage

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,20 +51,16 @@ Invoke-WebRequest -Uri https://github.com/Ensono/eirctl/releases/latest/download
 $env:PATH="${env:PATH};${binDir}"
 ```
 
-```sh
-https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-amd64.exe
-https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-arm64.exe
-https://github.com/Ensono/eirctl/releases/latest/download/eirctl-windows-386.exe
-```
-
 ### Verify installation
 
 ```bash
 eirctl --version
 ```
 
+Should output:
+
 ```output
-eirctl version v0.7.5-332295a31e95686cc9b20376d23a38cc98b45a00
+> eirctl version v0.7.5-332295a31e95686cc9b20376d23a38cc98b45a00
 ```
 
 ### Different Architectures

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -2,20 +2,20 @@
 
 Changes:
 
-- Context 
-    - container first class citizen 
-    - default mount point in the container is /workspace/.taskctl
-        - if you are referencing an absolute path this should be changed to reflect the new path. 
-        - _ALTERNATIVELY_, you should use relative paths, as the `-w /taskctl` is set and you are automatically in the root of your directory
+- Context
+  - container first class citizen
+  - default mount point in the container is /workspace/.taskctl
+    - if you are referencing an absolute path this should be changed to reflect the new path.
+    - _ALTERNATIVELY_, you should use relative paths, as the `-w /taskctl` is set and you are automatically in the root of your directory
 
 - env and envfile
-    - env is now added to Context, Pipelines, and Tasks
-        - It is merged in this order Context < Pipelines < Tasks - i.e. Tasks will overwrite anything set previously.
-    
-    - eirctl.env will be read in at a context level
+  - env is now added to Context, Pipelines, and Tasks
+    - It is merged in this order Context < Pipelines < Tasks - i.e. Tasks will overwrite anything set previously.
+
+  - eirctl.env will be read in at a context level
 
 - Scheduler
-    - denormalized graph allowing for a unique path to the same task
+  - denormalized graph allowing for a unique path to the same task
 
 ## Env
 
@@ -31,4 +31,5 @@ Changes:
 }
 ```
 
+> [!NOTE]
 > The authentication string is usually in the username:password format - the AuthFunc makes this assumption. So far all the Container Registries tested - ECR, ACR, Dockerhub, Gitlab - use this format. When the use case arises for an `identitytoken` it will be dealt with then.

--- a/docs/watchers.md
+++ b/docs/watchers.md
@@ -3,6 +3,7 @@
 ## Filesystem watchers
 
 Watcher watches for changes in files selected by provided patterns and triggers task anytime an event has occurred.
+
 ```yaml
 watchers:
   watcher1:
@@ -14,7 +15,7 @@ watchers:
 
 ### Patterns
 
-Thanks to [doublestar](https://github.com/bmatcuk/doublestar) *taskctl* supports the following special terms within include and exclude patterns:
+Thanks to [doublestar](https://github.com/bmatcuk/doublestar) *eirctl* supports the following special terms within include and exclude patterns:
 
 Special Terms | Meaning
 ------------- | -------


### PR DESCRIPTION
Was familiarising myself with `eirctl` and added some context for Windows users, and fixed a few minor typos and formatting issues.

Addresses documentation improvements across multiple markdown files to enhance clarity and user experience for `eirctl`. The changes focus on correcting typos, improving formatting with GitHub-flavored markdown admonitions, and providing better guidance for Windows users.

- Corrected references from `taskctl` to `eirctl` for consistency
- Enhanced installation instructions with detailed platform-specific guidance
- Improved documentation formatting using GitHub admonitions (NOTE, TIP, IMPORTANT, CAUTION)