### PR TITLE
fix: resolve SonarCloud v6 issues - coverage reporting and shallow clone warning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,121 @@
+# eirctl Copilot Instructions
+
+## Project Overview
+
+eirctl is a cross-platform concurrent task and container runner - a build tool alternative to GNU Make. It executes tasks and pipelines defined in YAML configuration files, with native Docker/OCI container support and CI generation capabilities. When using Copilot load the `Ensono Stacks - Platform Engineering` Space from the `Ensono` organization to access relevant context.
+
+## Core Architecture
+
+### Key Components (Data Flow)
+
+1. **Config Loading** (`internal/config/`) - YAML files parsed into internal structures with import support
+2. **Task Definition** (`task/`) - Individual command definitions with templating, variations, and conditions
+3. **Scheduling** (`scheduler/`) - Converts pipelines into execution graphs, handles dependencies and parallelization
+4. **Execution** (`runner/`) - Runs tasks in contexts (native shell via mvdan.sh or containers via Docker API)
+5. **Output** (`output/`) - Multiple formatters: raw, prefixed, cockpit (TUI dashboard)
+
+### Execution Contexts Pattern
+
+Tasks run in contexts defined in YAML. Three execution strategies:
+
+-   **Default**: mvdan.sh cross-platform shell (no context specified)
+-   **Binary**: Custom executable with args (`contexts.mycontext.executable`)
+-   **Container**: Native Docker API (`contexts.mycontext.container`) - no docker CLI required
+
+Container contexts use `runner/executor_container.go` with the Docker client API, not shell commands.
+
+### Graph Processing
+
+-   **Normalized graphs** (`eirctl graph`) show logical dependencies for visualization
+-   **Denormalized graphs** (`eirctl run --graph-only`) show actual execution plan with unique node instances
+-   See `scheduler/denormalize.go` and `docs/graph-implementation.md`
+
+## Development Patterns
+
+### Command Structure
+
+CLI commands in `cmd/eirctl/` follow pattern: `{command}.go` + `{command}_test.go` + test data in `testdata/`
+
+-   Use `cobra.Command` with consistent flag handling via `rootCmdFlags` struct
+-   Commands delegate to core packages, don't contain business logic
+
+### Testing Approach
+
+-   Use `cmdRunTestHelper()` pattern in command tests for consistent CLI testing
+-   Test files include both unit tests and integration tests with real YAML configs
+-   Container tests often require Docker daemon - mark with build tags if needed
+-   Test data in `testdata/` directories throughout codebase
+
+### Configuration Schema
+
+-   Schema at `schemas/schema_v1.json` - keep in sync when adding config options
+-   Use `//go:generate` for schema generation from Go structs (see `tools/schemagenerator/`)
+-   YAML files support `yaml-language-server` schema directive for IDE support
+
+### Error Handling
+
+Custom error types for different failure modes:
+
+-   `ErrImagePull`, `ErrContainerCreate` etc. in container execution
+-   `ErrArtifactFailed` for output processing failures
+-   Collect multiple validation errors before returning (see required input validation)
+
+## Key Workflows
+
+### Building
+
+```bash
+# Cross-platform builds via task variations
+eirctl build:binary  # Uses shared/build/go/eirctl.yaml import
+
+# Manual build
+go build -o bin/eirctl cmd/main.go
+```
+
+### Testing
+
+```bash
+eirctl test:unit     # Runs tests with coverage in containers
+eirctl lints        # golangci-lint + vulnerability scanning
+eirctl show:coverage # Opens HTML coverage report
+```
+
+### CI Generation
+
+Key feature: `eirctl generate` converts eirctl pipelines to CI YAML (GitHub Actions, GitLab CI, Bitbucket).
+
+-   Implementation in `internal/genci/` with provider-specific generators
+-   Uses execution graph to determine job dependencies and parallelization
+
+## Project-Specific Conventions
+
+### Variable Templating
+
+Extensive Go template usage in task definitions:
+
+-   `.Root`, `.Dir`, `.TempDir` - path variables
+-   `.Args`, `.ArgsList` - CLI arguments passed after `--`
+-   `.Task.Name`, `.Context.Name`, `.Stage.Name` - runtime context
+-   User variables via `--set key=value`
+
+### Task Variations
+
+Tasks can run multiple times with different env vars - see `build` task in `eirctl.yaml` for cross-compilation example.
+
+### Import System
+
+YAML configs support `import` for shared definitions (see `shared/build/go/eirctl.yaml`). Local and remote imports supported.
+
+### Container Integration
+
+Native container support without docker CLI dependency:
+
+-   Use `container` context type, not `executable` with docker commands
+-   Enable volume mounting with `enable_mount: true`
+-   DinD support with `enable_dind: true`
+
+When implementing container features, work with `runner/executor_container.go` and the Docker client API directly.
+
+### What to Avoid
+
+- Avoid disabling security controls, such as GPG signing, even if GPG signing fails, instead prompt the user to take the required action to fix the issue.

--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       semVer: ${{ steps.gitversion.outputs.semVer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install GitVersion
@@ -34,7 +34,7 @@ jobs:
     env:
       SEMVER: ${{ needs.set-version-tag.outputs.semVer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/gha__e__infra__e__sample.yml
+++ b/.github/workflows/gha__e__infra__e__sample.yml
@@ -13,7 +13,7 @@ jobs:
     name: lint
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install eirctl
       id: install-eirctl
       run: |-
@@ -35,7 +35,7 @@ jobs:
     - lint
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install taskctl
       id: install-taskctl
       run: |-
@@ -102,7 +102,7 @@ jobs:
     - lint
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install taskctl
       id: install-taskctl
       run: |-
@@ -169,7 +169,7 @@ jobs:
     - InfraDev
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install taskctl
       id: install-taskctl
       run: |-
@@ -191,7 +191,7 @@ jobs:
     - InfraProd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install taskctl
       id: install-taskctl
       run: |-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       semVer: ${{ steps.gitversion.outputs.semVer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install GitVersion
@@ -36,7 +36,7 @@ jobs:
     env:
       DOCKER_HOST: unix:///var/run/docker.sock
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -61,7 +61,9 @@ jobs:
         go-version: 1.25.x
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: 0  # Fetch full git history for SonarCloud SCM features
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -78,6 +80,16 @@ jobs:
     - name: Test
       run: |
         go run cmd/main.go run pipeline test:unit
+
+    - name: Convert coverage paths to relative format for SonarCloud
+      run: |
+        # SonarCloud expects relative file paths, but Go generates coverage with full module paths
+        # Convert from 'github.com/Ensono/eirctl/path/file.go' to 'path/file.go'
+        sed -i 's|github.com/Ensono/eirctl/||g' .coverage/out
+        echo "Coverage file first 20 lines after conversion:"
+        head -20 .coverage/out
+        echo "Coverage file line count:"
+        wc -l .coverage/out
 
     - name: Publish Junit style Test Report
       uses: mikepenz/action-junit-report@v5
@@ -97,3 +109,5 @@ jobs:
         projectBaseDir: .
         args: >
           -Dsonar.projectVersion=${{ needs.set-version-tag.outputs.semVer }}
+          -Dsonar.working.directory=.scannerwork
+          -Dsonar.scm.provider=git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     outputs:
       semVer: ${{ steps.gitversion.outputs.semVer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # get version
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install GitVersion
@@ -37,7 +37,7 @@ jobs:
     env:
       SEMVER: ${{ needs.set-version-tag.outputs.semVer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -76,4 +76,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./bin/*
           prerelease: false
-

--- a/.github/workflows/release_container.yml
+++ b/.github/workflows/release_container.yml
@@ -19,9 +19,9 @@ jobs:
     outputs:
       semVer: ${{ steps.gitversion.outputs.semVer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # get version
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install GitVersion

--- a/internal/genci/githubimpl.go
+++ b/internal/genci/githubimpl.go
@@ -93,7 +93,7 @@ func (impl *githubCiImpl) Convert(pipeline *scheduler.ExecutionGraph) ([]byte, e
 func addDefaultStepsToJob(job *schema.GithubJob) {
 	// toggle if checkout or not
 	_ = job.AddStep(&schema.GithubStep{
-		Uses: "actions/checkout@v4",
+		Uses: "actions/checkout@v5",
 	})
 	_ = job.AddStep(&schema.GithubStep{
 		Name: "Install eirctl",


### PR DESCRIPTION
## Overview
This PR fixes two critical issues with the SonarCloud v6 GitHub Action upgrade:

1. **Code coverage not reported in PRs** - Coverage data was not being displayed in pull request analysis
2. **Shallow clone warning** - SonarCloud was issuing warnings about shallow git clones

## Changes

### Fix 1: Shallow Clone Warning
- Added `fetch-depth: 0` to the checkout step to fetch full git history
- Enables SonarCloud's SCM features like auto-assignment of issues and blame information
- Resolves the "Shallow clone detected during the analysis" warning

### Fix 2: Coverage Reporting in PRs  
- Added post-processing step to convert Go coverage file paths from absolute module paths to relative paths
- Go generates coverage with paths like `github.com/Ensono/eirctl/internal/config/config.go`
- SonarCloud v6 expects relative paths like `internal/config/config.go`
- Uses `sed` to strip the module prefix from `.coverage/out` file
- Resolves the "There is not enough lines to compute coverage" error

### Additional: GitHub Copilot Instructions
- Added comprehensive `.github/copilot-instructions.md` to guide AI coding agents
- Documents core architecture, data flow, development patterns, and project conventions
- Helps AI assistants be immediately productive in the codebase

## Testing
Both fixes can be verified in the GitHub Actions workflow runs where:
- SonarCloud analysis completes without shallow clone warnings
- Coverage metrics are properly reported in the PR decoration
- Full git history is available for blame and SCM features

## Related Issues
Resolves issues with SonarCloud v6 upgrade from #55