### PR TITLE
fix: allow for ignoring of unparseable directives in SSH config files

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -170,7 +170,7 @@ var getGetConfigFunc []ConfigFunc = []ConfigFunc{
 			logrus.Debugf("import (%s) is a git path", file)
 			gs, err := NewGitSource(file)
 			if err != nil {
-				return false, nil, fmt.Errorf("%w\nerror: %v", ErrIncorrectlyFormattedGit, err)
+				return false, nil, fmt.Errorf("loader error: %v", err)
 			}
 			if err := gs.Clone(); err != nil {
 				return false, nil, err

--- a/internal/config/loader_git.go
+++ b/internal/config/loader_git.go
@@ -35,6 +35,7 @@ var (
 	// must have a repo url and path to file specified
 	gitRegexp                    = regexp.MustCompile(`^git::(ssh|https?|file)://(.+?)//([^?]+)(?:\?ref=([^&]+))?$`)
 	ErrIncorrectlyFormattedGit   = errors.New("incorrectly formatted git import, must satisfy this regex `^git::(ssh|https?|file)://(.+?)//([^?]+)(?:\\?ref=([^&]+))?$`")
+	ErrSSHConfig                 = errors.New("incorrect ssh config file")
 	ErrGitTagBranchRevisionWrong = errors.New("tag or branch or revision was not found")
 	ErrGitOperation              = errors.New("git operation failed")
 )
@@ -208,6 +209,7 @@ func (gs *GitSource) getGitSSHAuth(host string) (*gitssh.PublicKeys, error) {
 		sshConf.ConfigFile = sshDefaultConf.ConfigFile
 	}
 
+	ssh_config.DefaultUserSettings.IgnoreErrors = true
 	sshCfgFile := &ssh_config.Config{}
 	if sshConf.ConfigFile != "" {
 		f, err := os.Open(sshConf.ConfigFile)
@@ -215,15 +217,14 @@ func (gs *GitSource) getGitSSHAuth(host string) (*gitssh.PublicKeys, error) {
 			return nil, err
 		}
 		defer f.Close()
+
 		sshCfgFile, err = ssh_config.Decode(f)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w (%s)\n %v", ErrSSHConfig, sshConf.ConfigFile, err)
 		}
 	}
 
-	if err := processSSHConfig(sshCfgFile, sshConf, host); err != nil {
-		return nil, err
-	}
+	processSSHConfig(sshCfgFile, sshConf, host)
 
 	if sshConf.IdentityFile == "" {
 		sshConf.IdentityFile = sshDefaultConf.IdentityFile
@@ -323,8 +324,8 @@ func parseDefaultSshConfigFilePaths() *SSHConfigAuth {
 	return defaultFilePaths
 }
 
-// processSSHConfig extracts the relevant info from a config file, merging with
-func processSSHConfig(fileSSHCfg *ssh_config.Config, sshConfig *SSHConfigAuth, hostname string) error {
+// processSSHConfig extracts the relevant info from a config file, merging with the overrides and defaults
+func processSSHConfig(fileSSHCfg *ssh_config.Config, sshConfig *SSHConfigAuth, hostname string) {
 
 	if sshConfig.Port == "" {
 		filePort, _ := fileSSHCfg.Get(hostname, "Port")
@@ -353,5 +354,4 @@ func processSSHConfig(fileSSHCfg *ssh_config.Config, sshConfig *SSHConfigAuth, h
 		fileIdentityFile, _ := fileSSHCfg.Get(hostname, "IdentityFile")
 		sshConfig.IdentityFile = fileIdentityFile
 	}
-	return nil
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -295,6 +295,22 @@ func TestLoader_errors(t *testing.T) {
 			t.Fatal("got nil, wanted error")
 		}
 	})
+	t.Run("import over git fails", func(t *testing.T) {
+		dir, _ := os.MkdirTemp(os.TempDir(), "import-err*")
+		fname := filepath.Join(dir, "eirctl.yaml")
+
+		f, _ := os.Create(fname)
+		defer os.RemoveAll(dir)
+
+		f.Write([]byte(`import:
+  - git::wrong-proto://unknown.org/foo/bar//eirctl/component/eirctl.yaml?ref=v0.0.65`))
+
+		cl := config.NewConfigLoader(config.NewConfig())
+		_, err := cl.Load(f.Name())
+		if err == nil {
+			t.Fatal("got nil, wanted error")
+		}
+	})
 }
 
 func TestLoader_LoadGlobalConfig(t *testing.T) {


### PR DESCRIPTION
addresses #64 

add better error message for git config