### PR TITLE
fix: yaml marshalling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/emicklei/dot v1.11.0
 	github.com/fatih/color v1.19.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.0
+	github.com/go-git/go-git/v5 v5.19.1
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
 github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/config/definitions.go
+++ b/internal/config/definitions.go
@@ -145,7 +145,7 @@ type PipelineDefinition struct {
 	// later elements in the list will overwrite keys specified previously
 	Envfile *utils.Envfile `mapstructure:"envfile" yaml:"envfile,omitempty" json:"envfile,omitempty"`
 	// Variables is the Key: Value map of vars vars to inject into the tasks
-	Variables EnvVarMapType `mapstructure:"variables" yaml:"variables,omitempty" json:"variables,omitempty"`
+	Variables VariablesVarMapType `mapstructure:"variables" yaml:"variables,omitempty" json:"variables,omitempty"`
 	// Generator PipelineLevel
 	Generator map[string]any `mapstructure:"ci_meta,omitempty" yaml:"ci_meta,omitempty" json:"ci_meta,omitempty"`
 }

--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -52,7 +52,7 @@ func buildPipeline(g *scheduler.ExecutionGraph, stages []*PipelineDefinition, cf
 		}
 		stage.WithEnv(variables.FromMap(def.Env))
 		stage.WithEnvFile(def.Envfile)
-		vars := variables.FromMap(def.Variables)
+		vars := variables.FromVarsMap(def.Variables)
 		vars.Set(".Stage.Name", def.Name)
 		stage.WithVariables(vars)
 

--- a/internal/config/pipeline_test.go
+++ b/internal/config/pipeline_test.go
@@ -14,10 +14,10 @@ import (
 func TestBuildPipeline_Cyclical(t *testing.T) {
 
 	var cyclicalYaml = `pipelines:
-  pipeline1:    
+  pipeline1:
     - task: task1
       name: task1
-      depends_on: 
+      depends_on:
         - last-stage
       dir: "/root"
     - task: task2
@@ -27,7 +27,7 @@ func TestBuildPipeline_Cyclical(t *testing.T) {
       env: {}
     - task: task3
       name: last-stage
-      depends_on: 
+      depends_on:
         - task2
 
 tasks:
@@ -51,7 +51,7 @@ tasks:
 func TestBuildPipeline_Error(t *testing.T) {
 	t.Run("no such task", func(t *testing.T) {
 		var errorYaml = `pipelines:
-  pipeline1:    
+  pipeline1:
     - task: task4
       name: task4
       depends_on:
@@ -76,7 +76,7 @@ tasks:
 	})
 	t.Run("no such pipeline", func(t *testing.T) {
 		var errorYaml = `pipelines:
-  pipeline1:    
+  pipeline1:
     - pipeline: task4
       name: task4
       depends_on:
@@ -101,7 +101,7 @@ tasks:
 	})
 	t.Run("stage with same name", func(t *testing.T) {
 		var errorYaml = `pipelines:
-  pipeline1:    
+  pipeline1:
     - task: task1
       name: task1
       depends_on:
@@ -131,6 +131,84 @@ tasks:
 }
 
 func TestConfig_TaskLoader(t *testing.T) {
+	t.Run("task variables with string values", func(t *testing.T) {
+		yaml := `
+tasks:
+  task1:
+    command:
+      - echo hello
+    variables:
+      DockerEntrypoint: /bin/bash
+      Version: "1.2.3"
+`
+		file, cleanUp := configLoaderTestHelper(t, yaml)
+		defer cleanUp()
+		cl := config.NewConfigLoader(config.NewConfig())
+		cfg, err := cl.Load(file)
+		if err != nil {
+			t.Fatalf("unexpected load error: %v", err)
+		}
+		task, ok := cfg.Tasks["task1"]
+		if !ok {
+			t.Fatal("task1 not found in config")
+		}
+		if got := task.Variables.Get("DockerEntrypoint"); got != "/bin/bash" {
+			t.Errorf("DockerEntrypoint = %v, want /bin/bash", got)
+		}
+		if got := task.Variables.Get("Version"); got != "1.2.3" {
+			t.Errorf("Version = %v, want 1.2.3", got)
+		}
+	})
+
+	t.Run("task variables with sequence (list) value", func(t *testing.T) {
+		yaml := `
+tasks:
+  task1:
+    command:
+      - echo hello
+    variables:
+      DockerEntrypoint: /bin/bash
+      TestCmdList:
+        - Cmd: php --version
+          Path: php_v
+        - Cmd: php -m
+          Path: php_m
+        - Cmd: configmanager --version
+          Path: cfgmgr
+`
+		file, cleanUp := configLoaderTestHelper(t, yaml)
+		defer cleanUp()
+		cl := config.NewConfigLoader(config.NewConfig())
+		cfg, err := cl.Load(file)
+		if err != nil {
+			t.Fatalf("unexpected load error (sequence variable should be supported): %v", err)
+		}
+		task, ok := cfg.Tasks["task1"]
+		if !ok {
+			t.Fatal("task1 not found in config")
+		}
+		if got := task.Variables.Get("DockerEntrypoint"); got != "/bin/bash" {
+			t.Errorf("DockerEntrypoint = %v, want /bin/bash", got)
+		}
+		list, ok := task.Variables.Get("TestCmdList").([]any)
+		if !ok {
+			t.Fatalf("TestCmdList is %T, want []any", task.Variables.Get("TestCmdList"))
+		}
+		if len(list) != 3 {
+			t.Fatalf("TestCmdList length = %d, want 3", len(list))
+		}
+		first, ok := list[0].(config.VariablesVarMapType)
+		if !ok {
+			t.Fatalf("TestCmdList[0] is %T, want config.VariablesVarMapType", list[0])
+		}
+		if first["Cmd"] != "php --version" {
+			t.Errorf("TestCmdList[0].Cmd = %v, want 'php --version'", first["Cmd"])
+		}
+		if first["Path"] != "php_v" {
+			t.Errorf("TestCmdList[0].Path = %v, want 'php_v'", first["Path"])
+		}
+	})
+
 	t.Run("task correctly built from config using envfile as well as env keys", func(t *testing.T) {
 		tmpEnv, _ := os.CreateTemp("", "*.env")
 		defer os.Remove(tmpEnv.Name())
@@ -179,6 +257,94 @@ tasks:
 		}
 		if val.EnvFile.PathValue[0] != tmpEnv.Name() {
 			t.Error("incorrect env file name")
+		}
+	})
+}
+
+func TestBuildPipeline_Variables(t *testing.T) {
+	t.Run("pipeline stage variables with string values", func(t *testing.T) {
+		yaml := `
+pipelines:
+  pipeline1:
+    - task: task1
+      name: task1
+      variables:
+        DockerEntrypoint: /bin/bash
+        Version: "1.2.3"
+tasks:
+  task1:
+    command:
+      - echo hello
+`
+		file, cleanUp := configLoaderTestHelper(t, yaml)
+		defer cleanUp()
+		cl := config.NewConfigLoader(config.NewConfig())
+		cfg, err := cl.Load(file)
+		if err != nil {
+			t.Fatalf("unexpected load error: %v", err)
+		}
+		stage, err := cfg.Pipelines["pipeline1"].Node("task1")
+		if err != nil {
+			t.Fatalf("stage not found: %v", err)
+		}
+		if got := stage.Variables().Get("DockerEntrypoint"); got != "/bin/bash" {
+			t.Errorf("DockerEntrypoint = %v, want /bin/bash", got)
+		}
+		if got := stage.Variables().Get("Version"); got != "1.2.3" {
+			t.Errorf("Version = %v, want 1.2.3", got)
+		}
+	})
+
+	t.Run("pipeline stage variables with sequence (list) value", func(t *testing.T) {
+		yaml := `
+pipelines:
+  pipeline1:
+    - task: task1
+      name: task1
+      variables:
+        DockerEntrypoint: /bin/bash
+        TestCmdList:
+          - Cmd: php --version
+            Path: php_v
+          - Cmd: php -m
+            Path: php_m
+          - Cmd: configmanager --version
+            Path: cfgmgr
+tasks:
+  task1:
+    command:
+      - echo hello
+`
+		file, cleanUp := configLoaderTestHelper(t, yaml)
+		defer cleanUp()
+		cl := config.NewConfigLoader(config.NewConfig())
+		cfg, err := cl.Load(file)
+		if err != nil {
+			t.Fatalf("unexpected load error (sequence variable should be supported): %v", err)
+		}
+		stage, err := cfg.Pipelines["pipeline1"].Node("task1")
+		if err != nil {
+			t.Fatalf("stage not found: %v", err)
+		}
+		if got := stage.Variables().Get("DockerEntrypoint"); got != "/bin/bash" {
+			t.Errorf("DockerEntrypoint = %v, want /bin/bash", got)
+		}
+		list, ok := stage.Variables().Get("TestCmdList").([]any)
+		if !ok {
+			t.Fatalf("TestCmdList is %T, want []any", stage.Variables().Get("TestCmdList"))
+		}
+		if len(list) != 3 {
+			t.Fatalf("TestCmdList length = %d, want 3", len(list))
+		}
+		first, ok := list[0].(config.VariablesVarMapType)
+		if !ok {
+			t.Fatalf("TestCmdList[0] is %T, want config.VariablesVarMapType", list[0])
+		}
+		if first["Cmd"] != "php --version" {
+			t.Errorf("TestCmdList[0].Cmd = %v, want 'php --version'", first["Cmd"])
+		}
+		if first["Path"] != "php_v" {
+			t.Errorf("TestCmdList[0].Path = %v, want 'php_v'", first["Path"])
 		}
 	})
 }

--- a/schemas/schema_v1.json
+++ b/schemas/schema_v1.json
@@ -486,8 +486,7 @@
           "type": "string"
         },
         "description": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "condition": {
           "type": "string"

--- a/schemas/schema_v1.json
+++ b/schemas/schema_v1.json
@@ -429,7 +429,7 @@
           "description": "EnvFile definition to set on the stage (eirctl pipeline)\n\nIf a list is supplied than the order in which they are supplied will be respected\nlater elements in the list will overwrite keys specified previously"
         },
         "variables": {
-          "$ref": "#/$defs/EnvVarMapType",
+          "$ref": "#/$defs/VariablesVarMapType",
           "description": "Variables is the Key: Value map of vars vars to inject into the tasks"
         },
         "ci_meta": {
@@ -486,7 +486,8 @@
           "type": "string"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "condition": {
           "type": "string"


### PR DESCRIPTION
Fix for:
load import ({Src:/foo/deploy/ecs/app/eirctl.yaml Hash: Dest:}) error: yaml: unmarshal errors:
  line 139: cannot unmarshal !!seq into string, in file: ({Src:/foo/deploy/ecs/app/eirctl.yaml Hash: Dest:})
  
  Added support for variables parsing from any data type when defined on the pipeline level